### PR TITLE
state 삭제

### DIFF
--- a/src/main/java/com/wandering/Do/domain/promise/entity/Promise.java
+++ b/src/main/java/com/wandering/Do/domain/promise/entity/Promise.java
@@ -37,7 +37,7 @@ public class Promise {
     private Contact contact;
 
     @Enumerated(EnumType.STRING)
-    private Stats stats;
+    private State state;
 
     @Enumerated(EnumType.STRING)
     private List<Grade> grade;

--- a/src/main/java/com/wandering/Do/domain/promise/entity/Promise.java
+++ b/src/main/java/com/wandering/Do/domain/promise/entity/Promise.java
@@ -37,9 +37,6 @@ public class Promise {
     private Contact contact;
 
     @Enumerated(EnumType.STRING)
-    private State state;
-
-    @Enumerated(EnumType.STRING)
     private List<Grade> grade;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/wandering/Do/domain/promise/entity/State.java
+++ b/src/main/java/com/wandering/Do/domain/promise/entity/State.java
@@ -1,6 +1,6 @@
 package com.wandering.Do.domain.promise.entity;
 
-public enum Stats {
+public enum State {
     PENDING,
     NOW,
     PAST

--- a/src/main/java/com/wandering/Do/domain/promise/entity/State.java
+++ b/src/main/java/com/wandering/Do/domain/promise/entity/State.java
@@ -1,7 +1,0 @@
-package com.wandering.Do.domain.promise.entity;
-
-public enum State {
-    PENDING,
-    NOW,
-    PAST
-}

--- a/src/main/java/com/wandering/Do/domain/promise/util/impl/PromiseConverterImpl.java
+++ b/src/main/java/com/wandering/Do/domain/promise/util/impl/PromiseConverterImpl.java
@@ -2,7 +2,7 @@ package com.wandering.Do.domain.promise.util.impl;
 
 import com.wandering.Do.domain.promise.entity.Contact;
 import com.wandering.Do.domain.promise.entity.Promise;
-import com.wandering.Do.domain.promise.entity.Stats;
+import com.wandering.Do.domain.promise.entity.State;
 import com.wandering.Do.domain.promise.presentation.dto.req.PromiseWriteReq;
 import com.wandering.Do.domain.promise.presentation.dto.res.PromiseGetListRes;
 import com.wandering.Do.domain.promise.presentation.dto.res.PromiseGetRes;
@@ -26,7 +26,7 @@ public class PromiseConverterImpl implements PromiseConverter {
                 .user(user)
                 .gender(promiseWriteReq.getGender())
                 .tags(promiseWriteReq.getTags())
-                .stats(Stats.PENDING)
+                .state(State.PENDING)
                 .grade(promiseWriteReq.getGrade())
                 .build();
     }

--- a/src/main/java/com/wandering/Do/domain/promise/util/impl/PromiseConverterImpl.java
+++ b/src/main/java/com/wandering/Do/domain/promise/util/impl/PromiseConverterImpl.java
@@ -2,7 +2,6 @@ package com.wandering.Do.domain.promise.util.impl;
 
 import com.wandering.Do.domain.promise.entity.Contact;
 import com.wandering.Do.domain.promise.entity.Promise;
-import com.wandering.Do.domain.promise.entity.State;
 import com.wandering.Do.domain.promise.presentation.dto.req.PromiseWriteReq;
 import com.wandering.Do.domain.promise.presentation.dto.res.PromiseGetListRes;
 import com.wandering.Do.domain.promise.presentation.dto.res.PromiseGetRes;
@@ -26,7 +25,6 @@ public class PromiseConverterImpl implements PromiseConverter {
                 .user(user)
                 .gender(promiseWriteReq.getGender())
                 .tags(promiseWriteReq.getTags())
-                .state(State.PENDING)
                 .grade(promiseWriteReq.getGrade())
                 .build();
     }


### PR DESCRIPTION
## 📌 개요
promise 상태변환 하려고 코드를 살펴보는 중 state가 굳이 없어도 되는 기능이여서 삭제하였습니다
promise 상태변환 관련해서 다음 스프린트 때 회의 및 파트 분배하면 좋을거 같습니다🤘

## ✨ 작업 내용
- state Enum 삭제
- state를 사용한 필드 수정

## 📸 구현한 화면
